### PR TITLE
Implement GLSL shader support for image manipulation (GPU image processing)

### DIFF
--- a/build.py
+++ b/build.py
@@ -111,12 +111,14 @@ if sys.platform == "win32":
 # Setup the correct arguments and options based on the platform
 args = [
     "pyinstaller",
+    "src/main.py",
     "-n", "GimelStudio",
     "--noconsole",
     "--noconfirm",
     "--hidden-import",
     "pkg_resources.py2_warn",
-    "glcontext"
+    "--hidden-import",
+    "glcontext",
     ]
 
 if sys.platform == "linux" or sys.platform == "linux2":
@@ -127,7 +129,6 @@ elif sys.platform == "win32":
 else:
     raise NotImplementedError("Only Windows, Linux and MacOs are supported!")
 
-args.append("src/main.py")
 subprocess.call(args)
 
 # Create a new folder for custom node scripts then copy the

--- a/build.py
+++ b/build.py
@@ -115,7 +115,8 @@ args = [
     "--noconsole",
     "--noconfirm",
     "--hidden-import",
-    "pkg_resources.py2_warn"
+    "pkg_resources.py2_warn",
+    "glcontext"
     ]
 
 if sys.platform == "linux" or sys.platform == "linux2":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 wxpython==4.1.1
 gsnodegraph==0.2.7
 gswidgetkit==0.2.0
+moderngl==5.6.4
 numpy
 opencv-python

--- a/src/gimelstudio/application.py
+++ b/src/gimelstudio/application.py
@@ -25,8 +25,9 @@ from .node_importer import *
 import gimelstudio.constants as appconst
 from .config import AppConfiguration
 from .interface import artproviders
-from .core import Renderer, NODE_REGISTRY
 from .datafiles.icons import ICON_GIMELSTUDIO_ICO
+from .core import (Renderer, GLSLRenderer,
+                   NODE_REGISTRY)
 from .interface import (ImageViewportPanel, NodePropertiesPanel,
                         NodeGraphPanel, StatusBar, PreferencesDialog,
                         ExportImageHandler, NodeGraphDropTarget)
@@ -46,8 +47,9 @@ class ApplicationFrame(wx.Frame):
         self.appconfig = AppConfiguration(self)
         self.appconfig.Load()
 
-        # Renderer and node registry
+        # Initilize renderers and node registry
         self.renderer = Renderer(self)
+        self.glsl_renderer = GLSLRenderer()  # Maybe move this to nodegraph or something
         self.registry = NODE_REGISTRY
 
         # Set the program icon

--- a/src/gimelstudio/application.py
+++ b/src/gimelstudio/application.py
@@ -49,7 +49,7 @@ class ApplicationFrame(wx.Frame):
 
         # Initilize renderers and node registry
         self.renderer = Renderer(self)
-        self.glsl_renderer = GLSLRenderer()  # TODO: Maybe move this to nodegraph or something
+        self.glsl_renderer = GLSLRenderer()
         self.registry = NODE_REGISTRY
 
         # Set the program icon

--- a/src/gimelstudio/application.py
+++ b/src/gimelstudio/application.py
@@ -49,7 +49,7 @@ class ApplicationFrame(wx.Frame):
 
         # Initilize renderers and node registry
         self.renderer = Renderer(self)
-        self.glsl_renderer = GLSLRenderer()  # Maybe move this to nodegraph or something
+        self.glsl_renderer = GLSLRenderer()  # TODO: Maybe move this to nodegraph or something
         self.registry = NODE_REGISTRY
 
         # Set the program icon
@@ -429,6 +429,8 @@ class ApplicationFrame(wx.Frame):
         if quitdialog.ShowModal() == wx.ID_YES:
             # Save configuration settings before quit
             self.appconfig.Save()
+            # Make sure to release data used by GPU render engine
+            self.glsl_renderer.Release()
             # Un-int the app and window mgr
             quitdialog.Destroy()
             self._mgr.UnInit()

--- a/src/gimelstudio/core/__init__.py
+++ b/src/gimelstudio/core/__init__.py
@@ -2,4 +2,6 @@ from .datatypes import RenderImage
 from .eval_info import EvalInfo
 from .output_node import OutputNode
 from .renderer import Renderer
-from .registry import RegisterNode, UnregisterNode, NODE_REGISTRY
+from .glsl_renderer import GLSLRenderer
+from .registry import (RegisterNode, UnregisterNode,
+                       NODE_REGISTRY)

--- a/src/gimelstudio/core/glsl_renderer.py
+++ b/src/gimelstudio/core/glsl_renderer.py
@@ -15,7 +15,6 @@
 # ----------------------------------------------------------------------------
 
 import copy
-import os.path
 import hashlib
 
 import numpy as np
@@ -27,8 +26,8 @@ class GLSLRenderer(object):
     def __init__(self):
         self.glContext = mg.create_standalone_context(require=330)
 
-        self.src_texture = self.glContext.texture((4000, 4000), 4)
-        self.dst_texture = self.glContext.texture((4000, 4000), 4)
+        self.src_texture = self.glContext.texture((4000, 4000), 4, dtype='f1')
+        self.dst_texture = self.glContext.texture((4000, 4000), 4, dtype='f1')
         self.src_fbo = self.glContext.framebuffer(self.src_texture)
         self.dst_fbo = self.glContext.framebuffer(self.dst_texture)
 
@@ -62,6 +61,7 @@ class GLSLRenderer(object):
 
         # FIXME: this effectively means we are no longer working with 16-bit
         image = image.Image('numpy').astype('uint8')
+        # image = cv2.normalize(image, dst=None, alpha=0, beta=65535, norm_type=cv2.NORM_MINMAX)
         # print(image.dtype)
         image = image.copy(order='C')
         self.viewport = (0, 0, *image.shape[1::-1])
@@ -117,7 +117,7 @@ class GLSLRenderer(object):
         vao.render(mode=mg.TRIANGLE_STRIP)
 
     def LoadGLSLFile(self, path):
-        with open(os.path.abspath(path), 'r') as fp:
+        with open(path, 'r') as fp:
             glsl_shader = str(fp.read())
         return glsl_shader
 

--- a/src/gimelstudio/core/glsl_renderer.py
+++ b/src/gimelstudio/core/glsl_renderer.py
@@ -1,0 +1,131 @@
+# ----------------------------------------------------------------------------
+# Gimel Studio Copyright 2019-2021 by Noah Rahm and contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+import copy
+import os.path
+import hashlib
+
+import numpy as np
+import moderngl as mg
+from array import array
+
+
+class GLSLRenderer(object):
+    def __init__(self):
+        self.glContext = mg.create_standalone_context(require=330)
+
+        self.src_texture = self.glContext.texture((4000, 4000), 4)
+        self.dst_texture = self.glContext.texture((4000, 4000), 4)
+        self.src_fbo = self.glContext.framebuffer(self.src_texture)
+        self.dst_fbo = self.glContext.framebuffer(self.dst_texture)
+
+        self._programs = {}
+        self._vaos = {}
+
+        # Fullscreen quad in NDC
+        self.vertices = self.glContext.buffer(
+            array(
+                'f',
+                [
+                    # Triangle strip creating a fullscreen quad (x, y)
+                    -1,  1,  # upper left
+                    -1, -1,  # lower left
+                    1, 1,    # upper right
+                    1, -1,   # lower right
+                ]
+            )
+        )
+
+    def GetGLContext(self):
+        return self.glContext
+
+    def Swap(self):
+        """ Swap the textures. """
+        self.src_texture, self.dst_texture = self.dst_texture, self.src_texture
+        self.src_fbo, self.dst_fbo = self.dst_fbo, self.src_fbo
+
+    def Write(self, image):
+        # Do the writing to src_texture
+
+        # FIXME: this effectively means we are no longer working with 16-bit
+        image = image.Image('numpy').astype('uint8')
+        # print(image.dtype)
+        image = image.copy(order='C')
+        self.viewport = (0, 0, *image.shape[1::-1])
+
+        self.src_texture.write(image, viewport=self.viewport)
+        return self.viewport
+
+    def ReadNumpy(self):
+        """ Returns a ``numpy.ndarray`` image. """
+        raw = self.dst_fbo.read(components=4, dtype='f1', viewport=self.viewport)
+
+        img = np.frombuffer(raw, dtype='uint8').reshape((self.viewport[3], self.viewport[2], 4))
+        return img
+
+    def Render(self, frag_shader, props, image=None):
+        if image is not None:
+            self.viewport = self.Write(image)
+        hash_value = hashlib.md5(copy.copy(frag_shader).encode())
+        vao = self._vaos.get(hash_value)
+
+        if vao is None:
+            program = self.glContext.program(
+                vertex_shader="""
+                    #version 330
+                    in vec2 in_position;
+                    void main() {
+                        gl_Position = vec4(in_position, 0.0, 1.0);
+                    }
+                """,
+                fragment_shader=frag_shader,
+            )
+
+            vao = self.glContext.vertex_array(
+                program,
+                [
+                    (self.vertices, '2f', 'in_position'),
+                ]
+            )
+
+            self._programs[hash_value] = program
+            self._vaos[hash_value] = vao
+
+        # Pass in values into the shader
+        for prop in props:
+            value = props[prop]
+            if prop in program:
+                program[prop] = value
+
+        self.dst_fbo.use()
+        self.dst_fbo.clear()
+        self.dst_fbo.viewport = self.viewport
+        self.src_texture.use(0)
+        vao.render(mode=mg.TRIANGLE_STRIP)
+
+    def LoadGLSLFile(self, path):
+        with open(os.path.abspath(path), 'r') as fp:
+            glsl_shader = str(fp.read())
+        return glsl_shader
+
+    def Release(self):
+        self.src_fbo.release()
+        self.src_texture.release()
+        for prog in self._programs.values():
+            prog.release()
+        for vao in self._vaos.values():
+            vao.release()
+        self.vertices.release()

--- a/src/gimelstudio/core/glsl_renderer.py
+++ b/src/gimelstudio/core/glsl_renderer.py
@@ -24,19 +24,18 @@ from array import array
 
 class GLSLRenderer(object):
     def __init__(self):
-        self.glContext = mg.create_standalone_context(require=330)
-
-        self.src_texture = self.glContext.texture((4000, 4000), 4, dtype='f1')
-        self.src_texture2 = self.glContext.texture((4000, 4000), 4, dtype='f1')
-        self.dst_texture = self.glContext.texture((4000, 4000), 4, dtype='f1')
-        self.src_fbo = self.glContext.framebuffer(self.src_texture)
-        self.dst_fbo = self.glContext.framebuffer(self.dst_texture)
-
         self._programs = {}
         self._vaos = {}
 
+        self.gl_context = mg.create_standalone_context(require=330)
+        self.src_texture = self.gl_context.texture((4000, 4000), 4, dtype='f1')
+        self.src_texture2 = self.gl_context.texture((4000, 4000), 4, dtype='f1')
+        self.dst_texture = self.gl_context.texture((4000, 4000), 4, dtype='f1')
+        self.src_fbo = self.gl_context.framebuffer(self.src_texture)
+        self.dst_fbo = self.gl_context.framebuffer(self.dst_texture)
+
         # Fullscreen quad in NDC
-        self.vertices = self.glContext.buffer(
+        self.vertices = self.gl_context.buffer(
             array(
                 'f',
                 [
@@ -50,7 +49,7 @@ class GLSLRenderer(object):
         )
 
     def GetGLContext(self):
-        return self.glContext
+        return self.gl_context
 
     def Swap(self):
         """ Swap the textures. """
@@ -58,58 +57,60 @@ class GLSLRenderer(object):
         self.src_fbo, self.dst_fbo = self.dst_fbo, self.src_fbo
 
     def Write(self, image, texture):
-        # Do the writing to src_texture
+        """ Do the writing to src_texture """
 
-        # FIXME: this effectively means we are no longer working with 16-bit
+        # FIXME: This effectively means we are no longer working with 16-bit
         image = image.Image('numpy').astype('uint8')
         # image = cv2.normalize(image, dst=None, alpha=0, beta=65535, norm_type=cv2.NORM_MINMAX)
         # print(image.dtype)
         image = image.copy(order='C')
         viewport = (0, 0, *image.shape[1::-1])
-
         texture.write(image, viewport=viewport)
         return viewport
 
     def ReadNumpy(self):
         """ Returns a ``numpy.ndarray`` image. """
         raw = self.dst_fbo.read(components=4, dtype='f1', viewport=self.viewport)
-
         img = np.frombuffer(raw, dtype='uint8').reshape((self.viewport[3], self.viewport[2], 4))
         return img
 
-    def Render(self, frag_shader, props, image=None, image2=None):
-        if image is not None:
-            self.viewport = self.Write(image, self.src_texture)
+    def WriteViewports(self, image, image2):
+        if image2 is not None:
             self.viewport2 = self.Write(image2, self.src_texture2)
+        self.viewport = self.Write(image, self.src_texture)
+
+    def LoadGLSLFile(self, path):
+        with open(path, 'r') as fp:
+            glsl_shader = str(fp.read())
+        return glsl_shader
+
+    def Render(self, frag_shader, props, image, image2=None):
         hash_value = hashlib.md5(copy.copy(frag_shader).encode())
         vao = self._vaos.get(hash_value)
+        self.WriteViewports(image, image2)
 
         if vao is None:
-            program = self.glContext.program(
-                vertex_shader="""
-                    #version 330
-                    in vec2 in_position;
-                    void main() {
-                        gl_Position = vec4(in_position, 0.0, 1.0);
-                    }
-                """,
-                fragment_shader=frag_shader,
-            )
+            vertex_shader = """
+                #version 330
+                in vec2 in_position;
+                void main() {
+                    gl_Position = vec4(in_position, 0.0, 1.0);
+                }
+                """
 
-            program["image"] = 0
-            program["image2"] = 1
+            program = self.gl_context.program(vertex_shader=vertex_shader,
+                                              fragment_shader=frag_shader)
+            program["input_img"] = 0
+            if image2 is not None:
+                program["input_img2"] = 1
 
-            vao = self.glContext.vertex_array(
-                program,
-                [
-                    (self.vertices, '2f', 'in_position'),
-                ]
-            )
+            vao = self.gl_context.vertex_array(program,
+                                               [(self.vertices, '2f', 'in_position')])
 
             self._programs[hash_value] = program
             self._vaos[hash_value] = vao
 
-        # Pass in values into the shader
+        # Pass values into the shader
         for prop in props:
             value = props[prop]
             if prop in program:
@@ -122,14 +123,10 @@ class GLSLRenderer(object):
         self.src_texture2.use(1)
         vao.render(mode=mg.TRIANGLE_STRIP)
 
-    def LoadGLSLFile(self, path):
-        with open(path, 'r') as fp:
-            glsl_shader = str(fp.read())
-        return glsl_shader
-
     def Release(self):
         self.src_fbo.release()
         self.src_texture.release()
+        self.src_texture2.release()
         for prog in self._programs.values():
             prog.release()
         for vao in self._vaos.values():

--- a/src/gimelstudio/core/node/node.py
+++ b/src/gimelstudio/core/node/node.py
@@ -18,8 +18,6 @@ import os.path
 import wx
 from gsnodegraph import NodeBase as NodeView
 
-from gimelstudio.core import RenderImage
-
 
 class Node(NodeView):
     def __init__(self, nodegraph, _id):
@@ -60,8 +58,7 @@ class Node(NodeView):
 
     @property
     def GLSLRenderer(self):
-        # FIXME: shouldn't be reaching in this far!
-        return self.nodegraph.parent.GLSLRenderer
+        return self.nodegraph.GLSLRenderer
 
     def GetLabel(self):
         return self.NodeMeta["label"]

--- a/src/gimelstudio/core/node/node.py
+++ b/src/gimelstudio/core/node/node.py
@@ -219,7 +219,7 @@ class Node(NodeView):
         """
         pass
 
-    def RenderGLSL(self, path, props, image, image2):
+    def RenderGLSL(self, path, props, image, image2=None):
         shader_path = os.path.abspath(os.path.expanduser(os.path.expandvars(path)))
         shader = self.GLSLRenderer.LoadGLSLFile(shader_path)
         self.GLSLRenderer.Render(shader, props, image, image2)

--- a/src/gimelstudio/core/node/node.py
+++ b/src/gimelstudio/core/node/node.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 # ----------------------------------------------------------------------------
 
+import os.path
 import wx
 from gsnodegraph import NodeBase as NodeView
 
@@ -218,8 +219,9 @@ class Node(NodeView):
         """
         pass
 
-    def RenderGLSL(self, shader, props, image):
-        # glsl_shader = self.GLSLRenderer.LoadGLSLFile(path)
+    def RenderGLSL(self, path, props, image):
+        shader_path = os.path.abspath(os.path.expanduser(os.path.expandvars(path)))
+        shader = self.GLSLRenderer.LoadGLSLFile(shader_path)
         self.GLSLRenderer.Render(shader, props, image)
         return self.GLSLRenderer.ReadNumpy()
 

--- a/src/gimelstudio/core/node/node.py
+++ b/src/gimelstudio/core/node/node.py
@@ -57,6 +57,11 @@ class Node(NodeView):
         }
         return meta_info
 
+    @property
+    def GLSLRenderer(self):
+        # FIXME: shouldn't be reaching in this far!
+        return self.nodegraph.parent.GLSLRenderer
+
     def GetLabel(self):
         return self.NodeMeta["label"]
 
@@ -212,6 +217,11 @@ class Node(NodeView):
         :prop value: updated value of the property
         """
         pass
+
+    def RenderGLSL(self, shader, props, image):
+        # glsl_shader = self.GLSLRenderer.LoadGLSLFile(path)
+        self.GLSLRenderer.Render(shader, props, image)
+        return self.GLSLRenderer.ReadNumpy()
 
     def RefreshNodeGraph(self):
         """ Force a refresh of the Node Graph panel. """

--- a/src/gimelstudio/core/node/node.py
+++ b/src/gimelstudio/core/node/node.py
@@ -219,10 +219,10 @@ class Node(NodeView):
         """
         pass
 
-    def RenderGLSL(self, path, props, image):
+    def RenderGLSL(self, path, props, image, image2):
         shader_path = os.path.abspath(os.path.expanduser(os.path.expandvars(path)))
         shader = self.GLSLRenderer.LoadGLSLFile(shader_path)
-        self.GLSLRenderer.Render(shader, props, image)
+        self.GLSLRenderer.Render(shader, props, image, image2)
         return self.GLSLRenderer.ReadNumpy()
 
     def RefreshNodeGraph(self):

--- a/src/gimelstudio/core/node/property.py
+++ b/src/gimelstudio/core/node/property.py
@@ -107,12 +107,13 @@ class Property(object):
 class PositiveIntegerProp(Property):
     """ Allows the user to select a positive integer. """
 
-    def __init__(self, idname, default=0, min_val=0,
+    def __init__(self, idname, default=0, lbl_suffix="", min_val=0,
                  max_val=10, widget="slider", label="", visible=True):
         Property.__init__(self, idname, default, label, visible)
         self.min_value = min_val
         self.max_value = max_val
         self.widget = widget
+        self.lbl_suffix = lbl_suffix
 
         self._RunErrorCheck()
 
@@ -141,7 +142,7 @@ class PositiveIntegerProp(Property):
                                        label=self.GetLabel(),
                                        min_value=self.GetMinValue(),
                                        max_value=self.GetMaxValue(),
-                                       suffix="px", show_p=False,
+                                       suffix=self.lbl_suffix, show_p=False,
                                        size=(-1, 32))
 
         self.AddToFoldPanel(sizer, fold_panel, self.numberfield, spacing=10)

--- a/src/gimelstudio/core/output_node.py
+++ b/src/gimelstudio/core/output_node.py
@@ -1,4 +1,3 @@
-
 # ----------------------------------------------------------------------------
 # Gimel Studio Copyright 2019-2021 by Noah Rahm and contributors
 #

--- a/src/gimelstudio/corenodes/__init__.py
+++ b/src/gimelstudio/corenodes/__init__.py
@@ -1,5 +1,5 @@
 from .input import ImageNode
 from .blend import MixNode
-from .filter import BlurNode
+from .filter import BlurNode, OpacityNode
 from .output import OutputNode
 from .transform import FlipNode

--- a/src/gimelstudio/corenodes/__init__.py
+++ b/src/gimelstudio/corenodes/__init__.py
@@ -1,5 +1,5 @@
 from .input import ImageNode
-from .blend import MixNode
+from .blend import MixNode, AlphaOverNode
 from .filter import BlurNode, OpacityNode
 from .output import OutputNode
 from .transform import FlipNode

--- a/src/gimelstudio/corenodes/blend/alpha_over_node/__init__.py
+++ b/src/gimelstudio/corenodes/blend/alpha_over_node/__init__.py
@@ -1,2 +1,1 @@
-from .mix_node import MixNode
 from .alpha_over_node import AlphaOverNode

--- a/src/gimelstudio/corenodes/blend/alpha_over_node/alpha_over.glsl
+++ b/src/gimelstudio/corenodes/blend/alpha_over_node/alpha_over.glsl
@@ -20,14 +20,14 @@
 
 #version 330
 
-uniform sampler2D image;
-uniform sampler2D image2;
-out vec4 out_color;
+uniform sampler2D input_img;
+uniform sampler2D input_img2;
 uniform float factor;
+out vec4 output_img;
 
 void main() {
-    vec4 color = texelFetch(image, ivec2(gl_FragCoord.xy), 0);
-    vec4 color2 = texelFetch(image2, ivec2(gl_FragCoord.xy), 0);
+    vec4 color1 = texelFetch(input_img, ivec2(gl_FragCoord.xy), 0);
+    vec4 color2 = texelFetch(input_img2, ivec2(gl_FragCoord.xy), 0);
 
-    out_color = mix(color, color2, factor);
+    output_img = mix(color1, color2, factor);
 }

--- a/src/gimelstudio/corenodes/blend/alpha_over_node/alpha_over.glsl
+++ b/src/gimelstudio/corenodes/blend/alpha_over_node/alpha_over.glsl
@@ -1,0 +1,33 @@
+// ----------------------------------------------------------------------------
+// Gimel Studio Copyright 2019-2021 by Noah Rahm and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// FILE: alpha_over.glsl
+// AUTHOR(S): Noah Rahm
+// PURPOSE: Alpha over two images based on the factor
+// ----------------------------------------------------------------------------
+
+#version 330
+
+uniform sampler2D image;
+uniform sampler2D image2;
+out vec4 out_color;
+uniform float factor;
+
+void main() {
+    vec4 color = texelFetch(image, ivec2(gl_FragCoord.xy), 0);
+    vec4 color2 = texelFetch(image2, ivec2(gl_FragCoord.xy), 0);
+
+    out_color = mix(color, color2, factor);
+}

--- a/src/gimelstudio/corenodes/blend/alpha_over_node/alpha_over_node.py
+++ b/src/gimelstudio/corenodes/blend/alpha_over_node/alpha_over_node.py
@@ -1,0 +1,74 @@
+# ----------------------------------------------------------------------------
+# Gimel Studio Copyright 2019-2021 by Noah Rahm and contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+
+from gimelstudio import api
+
+
+class AlphaOverNode(api.Node):
+    def __init__(self, nodegraph, _id):
+        api.Node.__init__(self, nodegraph, _id)
+
+    @property
+    def NodeMeta(self):
+        meta_info = {
+            "label": "Alpha Over",
+            "author": "Gimel Studio",
+            "version": (0, 0, 1),
+            "category": "FILTER",
+            "description": "Alpha over two images together based on the factor.",
+        }
+        return meta_info
+
+    def NodeInitProps(self):
+        self.value = api.PositiveIntegerProp(
+            idname="Factor",
+            default=100,
+            min_val=0,
+            max_val=100,
+            widget=api.SLIDER_WIDGET,
+            label="Factor:"
+        )
+        self.NodeAddProp(self.value)
+
+    def NodeInitParams(self):
+        image1 = api.RenderImageParam('Image 1')
+        image2 = api.RenderImageParam('Image 2')
+
+        self.NodeAddParam(image1)
+        self.NodeAddParam(image2)
+
+    def NodeEvaluation(self, eval_info):
+        image1 = self.EvalParameter(eval_info, 'Image 1')
+        image2 = self.EvalParameter(eval_info, 'Image 2')
+        factor = self.EvalProperty(eval_info, 'Factor')
+
+        render_image = api.RenderImage()
+
+        # Make correction for slider range of 1-100
+        factor = (factor * 0.01)
+
+        props = {
+            "factor": factor
+        }
+        shader_src = "gimelstudio/corenodes/blend/alpha_over_node/alpha_over.glsl"
+        result = self.RenderGLSL(shader_src, props, image1, image2)
+
+        render_image.SetAsImage(result)
+        return render_image
+
+
+api.RegisterNode(AlphaOverNode, "corenode_alpha_over")

--- a/src/gimelstudio/corenodes/filter/__init__.py
+++ b/src/gimelstudio/corenodes/filter/__init__.py
@@ -1,1 +1,2 @@
 from .blur_node import BlurNode
+from .opacity_node import OpacityNode

--- a/src/gimelstudio/corenodes/filter/opacity_node/__init__.py
+++ b/src/gimelstudio/corenodes/filter/opacity_node/__init__.py
@@ -1,0 +1,1 @@
+from .opacity_node import *

--- a/src/gimelstudio/corenodes/filter/opacity_node/opacity.glsl
+++ b/src/gimelstudio/corenodes/filter/opacity_node/opacity.glsl
@@ -26,5 +26,6 @@ uniform float opacityValue;
 
 void main() {
     vec4 color = texelFetch(image, ivec2(gl_FragCoord.xy), 0);
-    out_color = vec4(color.r, color.g, color.b, opacityValue);
+    if (color.a > 0) out_color = vec4(color.r, color.g, color.b, opacityValue);
+    else out_color = color;
 }

--- a/src/gimelstudio/corenodes/filter/opacity_node/opacity.glsl
+++ b/src/gimelstudio/corenodes/filter/opacity_node/opacity.glsl
@@ -1,0 +1,30 @@
+// ----------------------------------------------------------------------------
+// Gimel Studio Copyright 2019-2021 by Noah Rahm and contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// FILE: opacity.glsl
+// AUTHOR(S): Noah Rahm
+// PURPOSE: Adjust the opacity of an RGBA image
+// ----------------------------------------------------------------------------
+
+#version 330
+
+uniform sampler2D image;
+out vec4 out_color;
+uniform float opacityValue;
+
+void main() {
+    vec4 color = texelFetch(image, ivec2(gl_FragCoord.xy), 0);
+    out_color = vec4(color.r, color.g, color.b, opacityValue);
+}

--- a/src/gimelstudio/corenodes/filter/opacity_node/opacity.glsl
+++ b/src/gimelstudio/corenodes/filter/opacity_node/opacity.glsl
@@ -15,17 +15,17 @@
 //
 // FILE: opacity.glsl
 // AUTHOR(S): Noah Rahm
-// PURPOSE: Adjust the opacity of an RGBA image
+// PURPOSE: Adjust the opacity of an image
 // ----------------------------------------------------------------------------
 
 #version 330
 
-uniform sampler2D image;
-out vec4 out_color;
-uniform float opacityValue;
+uniform sampler2D input_img;
+uniform float opacity_value;
+out vec4 output_img;
 
 void main() {
-    vec4 color = texelFetch(image, ivec2(gl_FragCoord.xy), 0);
-    if (color.a > 0) out_color = vec4(color.r, color.g, color.b, opacityValue);
-    else out_color = color;
+    vec4 color = texelFetch(input_img, ivec2(gl_FragCoord.xy), 0);
+    if (color.a > 0) output_img = vec4(color.r, color.g, color.b, opacity_value);
+    else output_img = color;
 }

--- a/src/gimelstudio/corenodes/filter/opacity_node/opacity_node.py
+++ b/src/gimelstudio/corenodes/filter/opacity_node/opacity_node.py
@@ -58,7 +58,7 @@ class OpacityNode(api.Node):
         opacity_value = (opacity_value * 0.01)
 
         props = {
-            "opacityValue": opacity_value
+            "opacity_value": opacity_value
         }
         shader_src = "gimelstudio/corenodes/filter/opacity_node/opacity.glsl"
         result = self.RenderGLSL(shader_src, props, image1)

--- a/src/gimelstudio/corenodes/filter/opacity_node/opacity_node.py
+++ b/src/gimelstudio/corenodes/filter/opacity_node/opacity_node.py
@@ -1,0 +1,85 @@
+# ----------------------------------------------------------------------------
+# Gimel Studio Copyright 2019-2021 by Noah Rahm and contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ----------------------------------------------------------------------------
+
+
+from gimelstudio import api
+
+
+class OpacityNode(api.Node):
+    def __init__(self, nodegraph, _id):
+        api.Node.__init__(self, nodegraph, _id)
+
+    @property
+    def NodeMeta(self):
+        meta_info = {
+            "label": "Opacity",
+            "author": "Gimel Studio",
+            "version": (0, 0, 1),
+            "category": "FILTER",
+            "description": "",
+        }
+        return meta_info
+
+    def NodeInitProps(self):
+        self.value = api.PositiveIntegerProp(
+            idname="Opacity Value",
+            default=25,
+            min_val=0,
+            max_val=100,
+            widget=api.SLIDER_WIDGET,
+            label="Opacity:",
+        )
+        self.NodeAddProp(self.value)
+
+    def NodeInitParams(self):
+        image = api.RenderImageParam('Image')
+        self.NodeAddParam(image)
+
+    def NodeEvaluation(self, eval_info):
+        image1 = self.EvalParameter(eval_info, 'Image')
+        opacity_value = self.EvalProperty(eval_info, 'Opacity Value')
+
+        render_image = api.RenderImage()
+
+        # Make correction for slider range of 1-100
+        opacity_value = (opacity_value * 0.01)
+
+        shader = """
+        #version 330
+
+        uniform sampler2D image;
+        out vec4 out_color;
+        uniform float opacityValue;
+
+        void main() {
+            vec4 color = texelFetch(image, ivec2(gl_FragCoord.xy), 0);
+            out_color = vec4(color.r, color.g, color.b, opacityValue);
+        }
+        """
+
+        props = {
+            "opacityValue": opacity_value
+        }
+        result = self.RenderGLSL(
+            shader,  # "./GimelStudio/corenodes/filter/opacity_node/opacity.glsl",
+            props,
+            image1)
+
+        render_image.SetAsImage(result)
+        return render_image
+
+
+api.RegisterNode(OpacityNode, "corenode_opacity")

--- a/src/gimelstudio/corenodes/filter/opacity_node/opacity_node.py
+++ b/src/gimelstudio/corenodes/filter/opacity_node/opacity_node.py
@@ -29,7 +29,7 @@ class OpacityNode(api.Node):
             "author": "Gimel Studio",
             "version": (0, 0, 1),
             "category": "FILTER",
-            "description": "",
+            "description": "Adjust the transparency of an image.",
         }
         return meta_info
 
@@ -57,26 +57,11 @@ class OpacityNode(api.Node):
         # Make correction for slider range of 1-100
         opacity_value = (opacity_value * 0.01)
 
-        shader = """
-        #version 330
-
-        uniform sampler2D image;
-        out vec4 out_color;
-        uniform float opacityValue;
-
-        void main() {
-            vec4 color = texelFetch(image, ivec2(gl_FragCoord.xy), 0);
-            out_color = vec4(color.r, color.g, color.b, opacityValue);
-        }
-        """
-
         props = {
             "opacityValue": opacity_value
         }
-        result = self.RenderGLSL(
-            shader,  # "./GimelStudio/corenodes/filter/opacity_node/opacity.glsl",
-            props,
-            image1)
+        shader_src = "gimelstudio/corenodes/filter/opacity_node/opacity.glsl"
+        result = self.RenderGLSL(shader_src, props, image1)
 
         render_image.SetAsImage(result)
         return render_image

--- a/src/gimelstudio/interface/nodegraph_pnl.py
+++ b/src/gimelstudio/interface/nodegraph_pnl.py
@@ -18,10 +18,11 @@ import wx
 import wx.lib.agw.flatmenu as flatmenu
 
 from gswidgetkit import Button, EVT_BUTTON, NumberField, EVT_NUMBERFIELD_CHANGE
-from gsnodegraph import (NodeGraph, EVT_GSNODEGRAPH_NODESELECT,
+from gsnodegraph import (EVT_GSNODEGRAPH_NODESELECT,
                          EVT_GSNODEGRAPH_NODECONNECT,
                          EVT_GSNODEGRAPH_NODEDISCONNECT,
                          EVT_GSNODEGRAPH_MOUSEZOOM)
+from gsnodegraph import NodeGraph as NodeGraphBase
 
 from gimelstudio.datafiles import (ICON_NODEGRAPH_PANEL, ICON_MORE_MENU_SMALL,
                                    ICON_MOUSE_LMB_MOVEMENT, ICON_MOUSE_LMB,
@@ -33,6 +34,15 @@ from .addnode_menu import AddNodeMenu
 ID_MENU_UNDOCKPANEL = wx.NewIdRef()
 ID_MENU_HIDEPANEL = wx.NewIdRef()
 ID_ADDNODEMENU = wx.NewIdRef()
+
+
+class NodeGraph(NodeGraphBase):
+    def __init__(self, parent, registry, *args, **kwds):
+        NodeGraphBase.__init__(self, parent, registry, *args, **kwds)
+
+    @property
+    def GLSLRenderer(self):
+        return self.parent.GLSLRenderer
 
 
 class NodeGraphPanel(wx.Panel):

--- a/src/gimelstudio/interface/nodegraph_pnl.py
+++ b/src/gimelstudio/interface/nodegraph_pnl.py
@@ -83,6 +83,7 @@ class NodeGraphPanel(wx.Panel):
         self.nodegraph.AddNode('corenode_opacity', wx.Point(300, 200))
         self.nodegraph.AddNode('corenode_outputcomposite', wx.Point(900, 270))
         self.nodegraph.AddNode('corenode_flip', wx.Point(500, 300))
+        self.nodegraph.AddNode('corenode_alpha_over', wx.Point(300, 350))
 
         main_sizer.Add(topbar, flag=wx.EXPAND | wx.LEFT | wx.RIGHT)
         main_sizer.Add(self.nodegraph, 1, flag=wx.EXPAND | wx.BOTH)

--- a/src/gimelstudio/interface/nodegraph_pnl.py
+++ b/src/gimelstudio/interface/nodegraph_pnl.py
@@ -80,7 +80,7 @@ class NodeGraphPanel(wx.Panel):
         self.nodegraph.AddNode('corenode_image', wx.Point(100, 30))
         self.nodegraph.AddNode('corenode_image', wx.Point(100, 200))
         self.nodegraph.AddNode('corenode_blur', wx.Point(600, 200))
-        self.nodegraph.AddNode('corenode_mix', wx.Point(300, 200))
+        self.nodegraph.AddNode('corenode_opacity', wx.Point(300, 200))
         self.nodegraph.AddNode('corenode_outputcomposite', wx.Point(900, 270))
         self.nodegraph.AddNode('corenode_flip', wx.Point(500, 300))
 
@@ -117,6 +117,10 @@ class NodeGraphPanel(wx.Panel):
     @property
     def PropertiesPanel(self):
         return self.parent.prop_pnl
+
+    @property
+    def GLSLRenderer(self):
+        return self.parent.glsl_renderer
 
     @property
     def Statusbar(self):

--- a/src/gimelstudio/node_importer.py
+++ b/src/gimelstudio/node_importer.py
@@ -15,4 +15,5 @@
 # ----------------------------------------------------------------------------
 
 
-from .corenodes import OutputNode, MixNode, ImageNode, BlurNode, FlipNode
+from .corenodes import (OutputNode, MixNode, ImageNode,
+                        BlurNode, FlipNode, AlphaOverNode)


### PR DESCRIPTION
This is a very difficult, work-in-progress PR to implement GLSL shader support (and thus GPU image processing) in the node API. It is currently demonstrable via the Opacity and Alpha Over Node, so feel free to test it out. 😃 

There are a bunch of things to be worked out before merging this PR:

- [x] Implement ability to have multiple image inputs into the shader. Currently, you can only pass a single image into the shader. This works for nodes like Opacity, but the ability to pass in multiple images is needed in order to implement nodes like Mix, etc.
- [x] Figure out loading GLSL from a file rather than hardcoding it in the python file.
- [x] Work on code organization. (e.g: what is the best place for the ``GLSLRenderer`` class?)
- [x] Refine the API (Passing in props to the shader could be easier, I think. Though, we don't want too much overhead.)
- [x] Make sure to call ``Release`` on application quit.
- ~~When two nodes in a row are using GLSL shaders, it would be nice to keep the data on the GPU to reduce overhead. This could be achieved with the ``Swap`` method, but details need to be worked out.~~ **Not in this PR**
- ~~Implement 16-bit support via (uint16). Currently, only has 8-bit (uint8) support.~~ **Not in this PR**

At the moment, this uses ModernGL to give us access to an OpenGL 3.3+ context. Maybe other libraries would be better?

I am open to your critiques and thoughts on possible solutions @iwoithe, @JohJakob and others... 

This will close #27 