### PR TITLE
Create the configuration file if it does not exist

### DIFF
--- a/src/gimelstudio/config.py
+++ b/src/gimelstudio/config.py
@@ -69,6 +69,14 @@ class AppConfiguration(AppData):
         try:
             os.makedirs(
                 os.path.expanduser("~/.gimelstudio/"), exist_ok=True)
+            
+            if not os.path.exists(path):
+                with open("gimelstudio/datafiles/default_config.json") as f:
+                    default_config = f.read()
+                
+                with open(path, "w+") as f:
+                    f.write(default_config)
+                
             with open(path, "r") as file:
                 self.prefs = json.load(file)
         except IOError:


### PR DESCRIPTION
### Description
If the configuration file for Gimel Studio didn't exist the preferences dialog would crash. 

### Related issue/s:
- N/A

### Checklist
- [x] I signed the [CLA](https://cla-assistant.io/GimelStudio/GimelStudio)
- [x] There are no unnecessary changes in this PR
- [x] Gimel Studio runs successfully with the changes in this PR
- [x] The changes in this PR follow the [style guides](https://github.com/GimelStudio/GimelStudio/blob/master/CONTRIBUTING.md#styleguides)