### PR TITLE
Load UI translation from config file

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -61,7 +61,8 @@ class MainApp(wx.App):
         self.SetAppName("GimelStudio")
 
         # Controls the current interface language
-        self.language = "LANGUAGE_ENGLISH"
+        self.language_prefix = "LANGUAGE_"
+        self.language = self.language_prefix + self.app_config.Config(keys=("Settings", "Interface", "Language")).upper()
 
         # Setup the Locale
         self.InitI18n()


### PR DESCRIPTION
### Description
Load the UI translation from the ``~/.gimelstudio/config.json`` file. Currently Gimel Studio needs to restart in order to apply the setting.

### Related issues
- N/A

### Systems Tested On
- Windows

### Checklist
- [x] I signed the [CLA](https://cla-assistant.io/GimelStudio/GimelStudio)
- [x] There are no unnecessary or out-of-scope changes in this PR
- [x] Gimel Studio runs successfully on the above system(s) with the changes in this PR
- [x] The changes in this PR follow the [style guides](https://github.com/GimelStudio/GimelStudio/blob/master/CONTRIBUTING.md#styleguides)
