### PR TITLE
Store the config file path as a constant

### DIFF
--- a/src/gimelstudio/config.py
+++ b/src/gimelstudio/config.py
@@ -16,6 +16,7 @@
 
 import os
 import json
+import os.path
 
 import gimelstudio.constants as appconst
 
@@ -30,6 +31,7 @@ class AppData(object):
         self.app_version = appconst.APP_VERSION
         self.app_version_tag = appconst.APP_VERSION_TAG
         self.app_version_full = appconst.APP_VERSION_FULL
+        self.app_config_file = appconst.APP_CONFIG_FILE
 
 
 class AppConfiguration(AppData):
@@ -65,19 +67,18 @@ class AppConfiguration(AppData):
                 return default
 
     def Load(self):
-        path = os.path.expanduser("~/.gimelstudio/pr1-config.json")
         try:
             os.makedirs(os.path.expanduser("~/.gimelstudio/"),
                         exist_ok=True)
 
-            if not os.path.exists(path):
+            if not os.path.exists(self.app_config_file):
                 with open("gimelstudio/datafiles/default_config.json") as f:
                     default_config = f.read()
 
-                with open(path, "w+") as f:
+                with open(self.app_config_file, "w+") as f:
                     f.write(default_config)
 
-            with open(path, "r") as file:
+            with open(self.app_config_file, "r") as file:
                 self.prefs = json.load(file)
         except IOError:
             pass  # Just use default
@@ -86,9 +87,8 @@ class AppConfiguration(AppData):
         # Add app version to file
         self.prefs['app_version'] = self.app_version_full
 
-        path = "~/.gimelstudio/pr1-config.json"
         try:
-            with open(os.path.expanduser(path), "w") as file:
+            with open(self.app_config_file, "w") as file:
                 json.dump(self.prefs, file, indent=4)
         except IOError:
             pass  # Not a big deal

--- a/src/gimelstudio/constants.py
+++ b/src/gimelstudio/constants.py
@@ -16,6 +16,7 @@
 
 import os
 import sys
+import os.path
 
 
 # Application
@@ -33,6 +34,8 @@ APP_DESCRIPTION = "Non-destructive, node-based 2D image graphics editor focused 
 APP_FULL_TITLE = "{0} v{1}".format(APP_NAME, APP_VERSION_FULL)
 
 APP_CREDITS = [""]
+
+APP_CONFIG_FILE = os.path.expanduser("~/.gimelstudio/pr1-config.json")
 
 # File system
 SUPPORTED_FT_OPEN_LIST = [


### PR DESCRIPTION
### Description
Store the file path of the ``config.json`` file in ``src/gimelstudio/constants.py``. Also imports ``os.path`` for ``os.path`` methods (see [here](https://stackoverflow.com/a/2725195)).

### Related issues
N/A

### Systems Tested On
- Windows 10

### Checklist
- [x] I signed the [CLA](https://cla-assistant.io/GimelStudio/GimelStudio)
- [x] There are no unnecessary or out-of-scope changes in this PR
- [x] Gimel Studio runs successfully on the above system(s) with the changes in this PR
- [x] The changes in this PR follow the [style guides](https://github.com/GimelStudio/GimelStudio/blob/master/CONTRIBUTING.md#styleguides)
