### PR TITLE
Add export option to property panel

### DIFF
--- a/src/gimelstudio/api/__init__.py
+++ b/src/gimelstudio/api/__init__.py
@@ -1,5 +1,5 @@
 from gimelstudio.core.node import (Node, Parameter, RenderImageParam, IntegerParam,
                                   Property, PositiveIntegerProp, XYZProp,
-                                  ChoiceProp, OpenFileChooserProp,
+                                  ChoiceProp, OpenFileChooserProp, ActionProp,
                                   SLIDER_WIDGET, SPINBOX_WIDGET)
 from gimelstudio.core import RenderImage, RegisterNode

--- a/src/gimelstudio/core/node/__init__.py
+++ b/src/gimelstudio/core/node/__init__.py
@@ -1,5 +1,5 @@
 from .node import Node
 from .parameter import Parameter, RenderImageParam, IntegerParam
 from .property import (Property, PositiveIntegerProp, XYZProp,
-                       ChoiceProp, OpenFileChooserProp, 
+                       ChoiceProp, OpenFileChooserProp, ActionProp,
                        SLIDER_WIDGET, SPINBOX_WIDGET)

--- a/src/gimelstudio/core/node/property.py
+++ b/src/gimelstudio/core/node/property.py
@@ -361,21 +361,21 @@ class ActionProp(Property):
     """
     Allows the user to click a button to perform an action
     """
-    def __init__(self, idname, default="", fpb_label="", label="", flat=False, action=None, visible=True):
-        Property.__init__(self, idname, default, label, visible)
-        self.label = label
-        if fpb_label != "":
-            self.fpb_label = fpb_label
+    def __init__(self, idname, default="", label="", btn_label="", flat=False, action=None, visible=True):
+        Property.__init__(self, idname, default, btn_label, visible)
+        self.btn_label = btn_label
+        if label != "":
+            self.label = label
         else:
-            self.fpb_label = label
+            self.label = btn_label
         self.flat = flat
         self.action = action
 
     def CreateUI(self, parent, sizer):
-        fold_panel = self.CreateFoldPanel(sizer, self.fpb_label)
+        fold_panel = self.CreateFoldPanel(sizer, self.label)
         fold_panel.SetBackgroundColour(wx.Colour(PROP_BG_COLOR))
 
-        self.button = Button(fold_panel, label=_(self.label), flat=self.flat, size=(-1, 30))
+        self.button = Button(fold_panel, label=_(self.btn_label), flat=self.flat, size=(-1, 30))
         self.AddToFoldPanel(sizer, fold_panel, self.button)
         self.button.Bind(EVT_BUTTON, self.action)
 

--- a/src/gimelstudio/core/node/property.py
+++ b/src/gimelstudio/core/node/property.py
@@ -355,3 +355,23 @@ class XYZProp(Property):
 
     def WidgetEventZ(self, event):
         self.SetValue((self.value[0], self.value[1], event.value))
+
+
+class ActionProp(Property):
+    """
+    Allows the user to click a button to perform an action
+    """
+    def __init__(self, idname, default="", label="", flat=False, action=None, visible=True):
+        Property.__init__(self, idname, default, label, visible)
+        self.label = label
+        self.flat = flat
+        self.action = action
+
+    def CreateUI(self, parent, sizer):
+        fold_panel = self.CreateFoldPanel(sizer)
+        fold_panel.SetBackgroundColour(wx.Colour(PROP_BG_COLOR))
+
+        self.button = Button(fold_panel, label=_(self.label), flat=self.flat, size=(-1, 30))
+        self.AddToFoldPanel(sizer, fold_panel, self.button)
+        self.button.Bind(EVT_BUTTON, self.action)
+

--- a/src/gimelstudio/core/node/property.py
+++ b/src/gimelstudio/core/node/property.py
@@ -361,14 +361,18 @@ class ActionProp(Property):
     """
     Allows the user to click a button to perform an action
     """
-    def __init__(self, idname, default="", label="", flat=False, action=None, visible=True):
+    def __init__(self, idname, default="", fpb_label="", label="", flat=False, action=None, visible=True):
         Property.__init__(self, idname, default, label, visible)
         self.label = label
+        if fpb_label != "":
+            self.fpb_label = fpb_label
+        else:
+            self.fpb_label = label
         self.flat = flat
         self.action = action
 
     def CreateUI(self, parent, sizer):
-        fold_panel = self.CreateFoldPanel(sizer)
+        fold_panel = self.CreateFoldPanel(sizer, self.fpb_label)
         fold_panel.SetBackgroundColour(wx.Colour(PROP_BG_COLOR))
 
         self.button = Button(fold_panel, label=_(self.label), flat=self.flat, size=(-1, 30))

--- a/src/gimelstudio/core/output_node.py
+++ b/src/gimelstudio/core/output_node.py
@@ -43,6 +43,7 @@ class OutputNode(api.Node):
     def NodeInitProps(self):
         self.export_button = api.ActionProp(
             idname="export",
+            fpb_label="Export",
             label="Export Image",
             action=self.OnExportButtonPressed
         )

--- a/src/gimelstudio/core/output_node.py
+++ b/src/gimelstudio/core/output_node.py
@@ -43,7 +43,7 @@ class OutputNode(api.Node):
     def NodeInitProps(self):
         self.export_button = api.ActionProp(
             idname="export",
-            label="Export",
+            label="Export Image",
             action=self.OnExportButtonPressed
         )
         self.NodeAddProp(self.export_button)

--- a/src/gimelstudio/core/output_node.py
+++ b/src/gimelstudio/core/output_node.py
@@ -14,7 +14,9 @@
 # limitations under the License.
 # ----------------------------------------------------------------------------
 
+import wx
 from gimelstudio import api
+from gimelstudio.interface import ExportImageHandler
 
 
 class OutputNode(api.Node):
@@ -38,12 +40,33 @@ class OutputNode(api.Node):
         }
         return meta_info
 
+    def NodeInitProps(self):
+        self.export_button = api.ActionProp(
+            idname="export",
+            label="Export",
+            action=self.OnExportButtonPressed
+        )
+        self.NodeAddProp(self.export_button)
+
     def NodeInitParams(self):
         p = api.RenderImageParam('Image', 'Image')
         self.NodeAddParam(p)
 
     def NodeEvaluation(self, eval_info):
         pass
+
+    def OnExportButtonPressed(self, event):
+        # TODO: This is messy. Need to find a cleaner solution to accessing the renderer
+        app_frame = self.nodegraph.parent.parent
+        image = app_frame.renderer.GetRender()
+        try:
+            export_handler = ExportImageHandler(app_frame, image.Image("oiio"))
+            export_handler.RunExport()
+        except AttributeError:
+            dlg = wx.MessageDialog(None,
+               _("Please render an image before attempting to export!"),
+               _("No Image to Export!"), style=wx.ICON_EXCLAMATION)
+            dlg.ShowModal()
 
 
 api.RegisterNode(OutputNode, "corenode_outputcomposite")


### PR DESCRIPTION
### Description
When the ``Output`` node is selected, show an export button in the property panel. This is an alias to ``File > Export Image As...``

### Related issues
- https://github.com/GimelStudio/GimelStudio/issues/105

### Systems Tested On
Windows 10

### Checklist
- [x] I signed the [CLA](https://cla-assistant.io/GimelStudio/GimelStudio)
- [x] There are no unnecessary or out-of-scope changes in this PR
- [x] Gimel Studio runs successfully on the above system(s) with the changes in this PR
- [x] The changes in this PR follow the [style guides](https://github.com/GimelStudio/GimelStudio/blob/master/CONTRIBUTING.md#styleguides)
