### PR TITLE
Remove unused imports

### DIFF
--- a/src/gimelstudio/application.py
+++ b/src/gimelstudio/application.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 # ----------------------------------------------------------------------------
 
-import time
 import webbrowser
 
 import wx

--- a/src/gimelstudio/interface/addnode_menu.py
+++ b/src/gimelstudio/interface/addnode_menu.py
@@ -14,11 +14,9 @@
 # limitations under the License.
 # ----------------------------------------------------------------------------
 
-import copy
 import wx
 import wx.adv
 import wx.stc
-from gswidgetkit import TextCtrl
 
 import gimelstudio.constants as const
 

--- a/src/gimelstudio/interface/artproviders/menubar.py
+++ b/src/gimelstudio/interface/artproviders/menubar.py
@@ -18,7 +18,7 @@
 
 import wx
 import wx.lib.agw.flatmenu as flatmenu
-from wx.lib.agw.artmanager import ArtManager, RendererBase, DCSaver
+from wx.lib.agw.artmanager import ArtManager, DCSaver
 from wx.lib.agw.fmresources import ControlFocus, ControlPressed
 
 from gimelstudio.constants import ACCENT_COLOR, DARK_COLOR

--- a/src/gimelstudio/interface/exportimage_dlg.py
+++ b/src/gimelstudio/interface/exportimage_dlg.py
@@ -16,9 +16,8 @@
 
 import os
 import wx
-import wx.stc as stc
 from gswidgetkit import (Button, EVT_BUTTON, NumberField, EVT_NUMBERFIELD,
-                         TextCtrl, Label, DropDown, EVT_DROPDOWN)
+                         Label, DropDown, EVT_DROPDOWN)
 
 import gimelstudio.constants as const
 

--- a/src/gimelstudio/interface/imageviewport_pnl.py
+++ b/src/gimelstudio/interface/imageviewport_pnl.py
@@ -20,7 +20,7 @@ from wx.lib.newevent import NewCommandEvent
 from gswidgetkit import (Button, EVT_BUTTON, NumberField, ZoomPanel,
                          EVT_NUMBERFIELD_CHANGE)
 
-from gimelstudio.constants import (AREA_BG_COLOR, AREA_TOPBAR_COLOR, PROP_BG_COLOR)
+from gimelstudio.constants import (AREA_BG_COLOR, AREA_TOPBAR_COLOR)
 from gimelstudio.datafiles import (ICON_IMAGEVIEWPORT_PANEL, ICON_MORE_MENU_SMALL,
                                    ICON_MOUSE_MMB, ICON_MOUSE_MMB_MOVEMENT,
                                    ICON_BRUSH_CHECKERBOARD)

--- a/src/nodes/corenodes/input/image_node.py
+++ b/src/nodes/corenodes/input/image_node.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 # ----------------------------------------------------------------------------
 
-import os
-
 from gimelstudio import api, constants
 
 


### PR DESCRIPTION
### Description
Remove unused imports highlighted by [lgtm.com](https://lgtm.com/projects/g/GimelStudio/GimelStudio/alerts/?mode=list&id=py%2Funused-import).

### Related issues
N/A

### Systems Tested On
- Windows 10

### Checklist
- [x] I signed the [CLA](https://cla-assistant.io/GimelStudio/GimelStudio)
- [x] There are no unnecessary or out-of-scope changes in this PR
- [x] Gimel Studio runs successfully on the above system(s) with the changes in this PR
- [x] The changes in this PR follow the [style guides](https://github.com/GimelStudio/GimelStudio/blob/master/CONTRIBUTING.md#styleguides)
