### PR TITLE
Add some vertical spacing to the popup menus

### DIFF
--- a/src/gimelstudio/application.py
+++ b/src/gimelstudio/application.py
@@ -304,6 +304,10 @@ class ApplicationFrame(wx.Frame):
         self.menubar.Append(render_menu, _("Render"))
         self.menubar.Append(window_menu, _("Window"))
         self.menubar.Append(help_menu, _("Help"))
+        
+        for item in self.menubar._items:
+            item.GetMenu()._marginHeight = self.menubar._margin + 18
+            item.GetMenu().ResizeMenu()
 
         # Menu event bindings
         self.Bind(flatmenu.EVT_FLAT_MENU_SELECTED,

--- a/src/gimelstudio/application.py
+++ b/src/gimelstudio/application.py
@@ -305,6 +305,7 @@ class ApplicationFrame(wx.Frame):
         self.menubar.Append(window_menu, _("Window"))
         self.menubar.Append(help_menu, _("Help"))
         
+        # Adds vertical spacing to the menubar popups
         for item in self.menubar._items:
             item.GetMenu()._marginHeight = self.menubar._margin + 18
             item.GetMenu().ResizeMenu()

--- a/src/gimelstudio/application.py
+++ b/src/gimelstudio/application.py
@@ -67,7 +67,7 @@ class ApplicationFrame(wx.Frame):
 
         # Set the dark theme
         rm = self.menubar.GetRendererManager()
-        theme = rm.AddRenderer(artproviders.UIMenuBarRenderer())
+        theme = rm.AddRenderer(artproviders.UIMenuBarRenderer(self.menubar._margin))
         rm.SetTheme(theme)
 
         # Init menus

--- a/src/gimelstudio/application.py
+++ b/src/gimelstudio/application.py
@@ -67,7 +67,7 @@ class ApplicationFrame(wx.Frame):
 
         # Set the dark theme
         rm = self.menubar.GetRendererManager()
-        theme = rm.AddRenderer(artproviders.UIMenuBarRenderer(self.menubar._margin))
+        theme = rm.AddRenderer(artproviders.UIMenuBarRenderer())
         rm.SetTheme(theme)
 
         # Init menus

--- a/src/gimelstudio/interface/artproviders/menubar.py
+++ b/src/gimelstudio/interface/artproviders/menubar.py
@@ -29,7 +29,7 @@ def switchRGBtoBGR(colour):
 
 
 class UIMenuBarRenderer(flatmenu.FMRenderer):
-    def __init__(self):
+    def __init__(self, itemPadding):
         flatmenu.FMRenderer.__init__(self)
 
         self.highlightCheckAndRadio = True
@@ -54,7 +54,7 @@ class UIMenuBarRenderer(flatmenu.FMRenderer):
         self.buttonPressedFaceColour = wx.Colour(ACCENT_COLOR)
         self.buttonPressedBorderColour = wx.Colour(ACCENT_COLOR)
         
-        self.itemPadding = 16
+        self.itemPadding = itemPadding
 
 
     def DrawSeparator(self, dc, xCoord, yCoord, textX, sepWidth):

--- a/src/gimelstudio/interface/artproviders/menubar.py
+++ b/src/gimelstudio/interface/artproviders/menubar.py
@@ -53,6 +53,8 @@ class UIMenuBarRenderer(flatmenu.FMRenderer):
         self.buttonFocusBorderColour = wx.Colour(ACCENT_COLOR)
         self.buttonPressedFaceColour = wx.Colour(ACCENT_COLOR)
         self.buttonPressedBorderColour = wx.Colour(ACCENT_COLOR)
+        
+        self.itemPadding = 16
 
 
     def DrawSeparator(self, dc, xCoord, yCoord, textX, sepWidth):
@@ -97,7 +99,7 @@ class UIMenuBarRenderer(flatmenu.FMRenderer):
         """
 
         borderXSize = item._parentMenu.GetBorderXWidth()
-        itemHeight = item._parentMenu.GetItemHeight()
+        itemHeight = item._parentMenu.GetItemHeight() + self.itemPadding
         menuWidth = item._parentMenu.GetMenuWidth()
 
         # Define the item actual rectangle area
@@ -219,7 +221,7 @@ class UIMenuBarRenderer(flatmenu.FMRenderer):
                 w3, dummy = dc.GetTextExtent(text3)
 
                 posx = xCoord + textX + borderXSize
-                posy = (itemHeight - h) / 2 + yCoord
+                posy = (itemHeight - h) / 2 + yCoord + self.itemPadding
 
                 # Draw first part
                 dc.DrawText(text1, posx, posy)
@@ -597,7 +599,7 @@ class UIMenuBarRenderer(flatmenu.FMRenderer):
         # If we have to scroll and are not using the scroll bar buttons we need to draw
         # the scroll up menu item at the top.
         if not self.scrollBarButtons and flatmenu._showScrollButtons:
-            posy += flatmenu.GetItemHeight()
+            posy += flatmenu.GetItemHeight() + self.itemPadding
 
         for nCount in range(flatmenu._first, nItems):
 
@@ -620,7 +622,7 @@ class UIMenuBarRenderer(flatmenu.FMRenderer):
             # make sure we draw only visible items
             pp = flatmenu.ClientToScreen(wx.Point(0, posy))
 
-            menuBottom = (self.scrollBarButtons and [pp.y] or [pp.y + flatmenu.GetItemHeight()*2])[0]
+            menuBottom = (self.scrollBarButtons and [pp.y] or [pp.y + flatmenu.GetItemHeight() + self.itemPadding * 2])[0]
 
             if menuBottom > screenHeight:
                 break
@@ -631,4 +633,4 @@ class UIMenuBarRenderer(flatmenu.FMRenderer):
             if flatmenu._downButton:
                 flatmenu._downButton.Draw(mem_dc)
 
-        dc.Blit(0, 0, menuBmp.GetWidth(), menuBmp.GetHeight(), mem_dc, 0, 0)
+        dc.Blit(0, 0, menuBmp.GetWidth(), menuBmp.GetHeight() + self.itemPadding, mem_dc, 0, 0)

--- a/src/gimelstudio/interface/artproviders/menubar.py
+++ b/src/gimelstudio/interface/artproviders/menubar.py
@@ -29,7 +29,7 @@ def switchRGBtoBGR(colour):
 
 
 class UIMenuBarRenderer(flatmenu.FMRenderer):
-    def __init__(self, itemPadding):
+    def __init__(self):
         flatmenu.FMRenderer.__init__(self)
 
         self.highlightCheckAndRadio = True
@@ -53,9 +53,6 @@ class UIMenuBarRenderer(flatmenu.FMRenderer):
         self.buttonFocusBorderColour = wx.Colour(ACCENT_COLOR)
         self.buttonPressedFaceColour = wx.Colour(ACCENT_COLOR)
         self.buttonPressedBorderColour = wx.Colour(ACCENT_COLOR)
-        
-        self.itemPadding = itemPadding
-
 
     def DrawSeparator(self, dc, xCoord, yCoord, textX, sepWidth):
         """
@@ -99,7 +96,7 @@ class UIMenuBarRenderer(flatmenu.FMRenderer):
         """
 
         borderXSize = item._parentMenu.GetBorderXWidth()
-        itemHeight = item._parentMenu.GetItemHeight() + self.itemPadding
+        itemHeight = item._parentMenu.GetItemHeight()
         menuWidth = item._parentMenu.GetMenuWidth()
 
         # Define the item actual rectangle area
@@ -221,7 +218,7 @@ class UIMenuBarRenderer(flatmenu.FMRenderer):
                 w3, dummy = dc.GetTextExtent(text3)
 
                 posx = xCoord + textX + borderXSize
-                posy = (itemHeight - h) / 2 + yCoord + self.itemPadding
+                posy = (itemHeight - h) / 2 + yCoord
 
                 # Draw first part
                 dc.DrawText(text1, posx, posy)
@@ -599,7 +596,7 @@ class UIMenuBarRenderer(flatmenu.FMRenderer):
         # If we have to scroll and are not using the scroll bar buttons we need to draw
         # the scroll up menu item at the top.
         if not self.scrollBarButtons and flatmenu._showScrollButtons:
-            posy += flatmenu.GetItemHeight() + self.itemPadding
+            posy += flatmenu.GetItemHeight()
 
         for nCount in range(flatmenu._first, nItems):
 
@@ -610,7 +607,7 @@ class UIMenuBarRenderer(flatmenu.FMRenderer):
                               flatmenu._textX, flatmenu._rightMarginPosX,
                               nCount == flatmenu._selectedItem,
                               backgroundImage=backgroundImage)
-            posy += item.GetHeight() + self.itemPadding
+            posy += item.GetHeight()
             item.Show()
 
             if visibleItems >= switch:
@@ -622,7 +619,7 @@ class UIMenuBarRenderer(flatmenu.FMRenderer):
             # make sure we draw only visible items
             pp = flatmenu.ClientToScreen(wx.Point(0, posy))
 
-            menuBottom = (self.scrollBarButtons and [pp.y] or [pp.y + flatmenu.GetItemHeight() + self.itemPadding * 2])[0]
+            menuBottom = (self.scrollBarButtons and [pp.y] or [pp.y + flatmenu.GetItemHeight() * 2])[0]
 
             if menuBottom > screenHeight:
                 break
@@ -633,4 +630,4 @@ class UIMenuBarRenderer(flatmenu.FMRenderer):
             if flatmenu._downButton:
                 flatmenu._downButton.Draw(mem_dc)
 
-        dc.Blit(0, 0, menuBmp.GetWidth(), menuBmp.GetHeight() + self.itemPadding, mem_dc, 0, 0)
+        dc.Blit(0, 0, menuBmp.GetWidth(), menuBmp.GetHeight(), mem_dc, 0, 0)

--- a/src/gimelstudio/interface/artproviders/menubar.py
+++ b/src/gimelstudio/interface/artproviders/menubar.py
@@ -610,7 +610,7 @@ class UIMenuBarRenderer(flatmenu.FMRenderer):
                               flatmenu._textX, flatmenu._rightMarginPosX,
                               nCount == flatmenu._selectedItem,
                               backgroundImage=backgroundImage)
-            posy += item.GetHeight()
+            posy += item.GetHeight() + self.itemPadding
             item.Show()
 
             if visibleItems >= switch:


### PR DESCRIPTION
### Description
Adds padding to each item in the popup menus.

### Related issues
- https://github.com/GimelStudio/GimelStudio/issues/126

### Systems Tested On
- Windows 10

### Checklist
- [x] I signed the [CLA](https://cla-assistant.io/GimelStudio/GimelStudio)
- [x] There are no unnecessary or out-of-scope changes in this PR
- [x] Gimel Studio runs successfully on the above system(s) with the changes in this PR
- [x] The changes in this PR follow the [style guides](https://github.com/GimelStudio/GimelStudio/blob/master/CONTRIBUTING.md#styleguides)
