### PR TITLE
Fixed uppercase file extensions not being recognized.

### DIFF
--- a/src/gimelstudio/core/node/property.py
+++ b/src/gimelstudio/core/node/property.py
@@ -285,7 +285,7 @@ class OpenFileChooserProp(Property):
 
         if dlg.ShowModal() == wx.ID_OK:
             paths = dlg.GetPaths()
-            filetype = os.path.splitext(paths[0])[1]
+            filetype = os.path.splitext(paths[0])[1].lower()
 
             if filetype not in SUPPORTED_FT_OPEN_LIST:
                 dlg = wx.MessageDialog(None, _("That file type isn't currently supported!"),


### PR DESCRIPTION
<!-- Add a description -->
### Description

The file type check is case sensitive and f.e. "test.JPG" is not recognized as a valid extension.

Many cameras/phones default to uppercase file type extensions and can't be loaded.

This change should fix that.