### PR TITLE
Update Copyright To 2023

### DIFF
--- a/assets/encode_bitmaps.py
+++ b/assets/encode_bitmaps.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Gimel Studio Copyright 2019-2022 by the Gimel Studio project contributors
+# Gimel Studio Copyright 2019-2023 by the Gimel Studio project contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/assets/encode_splash.py
+++ b/assets/encode_splash.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Gimel Studio Copyright 2019-2022 by the Gimel Studio project contributors
+# Gimel Studio Copyright 2019-2023 by the Gimel Studio project contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/build.py
+++ b/build.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Gimel Studio Copyright 2019-2022 by the Gimel Studio project contributors
+# Gimel Studio Copyright 2019-2023 by the Gimel Studio project contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/gimelstudio/api/api.py
+++ b/src/gimelstudio/api/api.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Gimel Studio Copyright 2019-2022 by the Gimel Studio project contributors
+# Gimel Studio Copyright 2019-2023 by the Gimel Studio project contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/gimelstudio/application.py
+++ b/src/gimelstudio/application.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Gimel Studio Copyright 2019-2022 by the Gimel Studio project contributors
+# Gimel Studio Copyright 2019-2023 by the Gimel Studio project contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/gimelstudio/config.py
+++ b/src/gimelstudio/config.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Gimel Studio Copyright 2019-2022 by the Gimel Studio project contributors
+# Gimel Studio Copyright 2019-2023 by the Gimel Studio project contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/gimelstudio/constants.py
+++ b/src/gimelstudio/constants.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Gimel Studio Copyright 2019-2022 by the Gimel Studio project contributors
+# Gimel Studio Copyright 2019-2023 by the Gimel Studio project contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ APP_VERSION_FULL = "{0}{1}".format(APP_VERSION, APP_VERSION_TAG)
 
 APP_NAME = "Gimel Studio"
 APP_DESCRIPTION = "Non-destructive, node-based 2D image graphics editor focused on simplicity, speed, elegance & usability"
-APP_COPYRIGHT = "© 2019–2022 Gimel Studio contributors"
+APP_COPYRIGHT = "© 2019–2023 Gimel Studio contributors"
 
 APP_WEBSITE_URL = "https://gimelstudio.github.io"
 APP_LICENSE_URL = "https://github.com/GimelStudio/GimelStudio/blob/master/LICENSE"

--- a/src/gimelstudio/core/datatypes.py
+++ b/src/gimelstudio/core/datatypes.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Gimel Studio Copyright 2019-2022 by the Gimel Studio project contributors
+# Gimel Studio Copyright 2019-2023 by the Gimel Studio project contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/gimelstudio/core/eval_info.py
+++ b/src/gimelstudio/core/eval_info.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Gimel Studio Copyright 2019-2022 by the Gimel Studio project contributors
+# Gimel Studio Copyright 2019-2023 by the Gimel Studio project contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/gimelstudio/core/glsl_renderer.py
+++ b/src/gimelstudio/core/glsl_renderer.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Gimel Studio Copyright 2019-2022 by the Gimel Studio project contributors
+# Gimel Studio Copyright 2019-2023 by the Gimel Studio project contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/gimelstudio/core/id_pool.py
+++ b/src/gimelstudio/core/id_pool.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Gimel Studio Copyright 2019-2022 by the Gimel Studio project contributors
+# Gimel Studio Copyright 2019-2023 by the Gimel Studio project contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/gimelstudio/core/node/node.py
+++ b/src/gimelstudio/core/node/node.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Gimel Studio Copyright 2019-2022 by the Gimel Studio project contributors
+# Gimel Studio Copyright 2019-2023 by the Gimel Studio project contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/gimelstudio/core/node/property.py
+++ b/src/gimelstudio/core/node/property.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Gimel Studio Copyright 2019-2022 by the Gimel Studio project contributors
+# Gimel Studio Copyright 2019-2023 by the Gimel Studio project contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/gimelstudio/core/output_node.py
+++ b/src/gimelstudio/core/output_node.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Gimel Studio Copyright 2019-2022 by the Gimel Studio project contributors
+# Gimel Studio Copyright 2019-2023 by the Gimel Studio project contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/gimelstudio/core/project_file.py
+++ b/src/gimelstudio/core/project_file.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Gimel Studio Copyright 2019-2022 by the Gimel Studio project contributors
+# Gimel Studio Copyright 2019-2023 by the Gimel Studio project contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/gimelstudio/core/registry.py
+++ b/src/gimelstudio/core/registry.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Gimel Studio Copyright 2019-2022 by the Gimel Studio project contributors
+# Gimel Studio Copyright 2019-2023 by the Gimel Studio project contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/gimelstudio/core/renderer.py
+++ b/src/gimelstudio/core/renderer.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Gimel Studio Copyright 2019-2022 by the Gimel Studio project contributors
+# Gimel Studio Copyright 2019-2023 by the Gimel Studio project contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/gimelstudio/interface/about_dlg.py
+++ b/src/gimelstudio/interface/about_dlg.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Gimel Studio Copyright 2019-2022 by the Gimel Studio project contributors
+# Gimel Studio Copyright 2019-2023 by the Gimel Studio project contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/gimelstudio/interface/addnode_menu.py
+++ b/src/gimelstudio/interface/addnode_menu.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Gimel Studio Copyright 2019-2022 by the Gimel Studio project contributors
+# Gimel Studio Copyright 2019-2023 by the Gimel Studio project contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/gimelstudio/interface/artproviders/dockart.py
+++ b/src/gimelstudio/interface/artproviders/dockart.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Gimel Studio Copyright 2019-2022 by the Gimel Studio project contributors
+# Gimel Studio Copyright 2019-2023 by the Gimel Studio project contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/gimelstudio/interface/artproviders/menubar.py
+++ b/src/gimelstudio/interface/artproviders/menubar.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Gimel Studio Copyright 2019-2022 by the Gimel Studio project contributors
+# Gimel Studio Copyright 2019-2023 by the Gimel Studio project contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/gimelstudio/interface/exportimage_dlg.py
+++ b/src/gimelstudio/interface/exportimage_dlg.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Gimel Studio Copyright 2019-2022 by the Gimel Studio project contributors
+# Gimel Studio Copyright 2019-2023 by the Gimel Studio project contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/gimelstudio/interface/imageviewport_pnl.py
+++ b/src/gimelstudio/interface/imageviewport_pnl.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Gimel Studio Copyright 2019-2022 by the Gimel Studio project contributors
+# Gimel Studio Copyright 2019-2023 by the Gimel Studio project contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/gimelstudio/interface/message_dlgs.py
+++ b/src/gimelstudio/interface/message_dlgs.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Gimel Studio Copyright 2019-2022 by the Gimel Studio project contributors
+# Gimel Studio Copyright 2019-2023 by the Gimel Studio project contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/gimelstudio/interface/nodegraph_dnd.py
+++ b/src/gimelstudio/interface/nodegraph_dnd.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Gimel Studio Copyright 2019-2022 by the Gimel Studio project contributors
+# Gimel Studio Copyright 2019-2023 by the Gimel Studio project contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/gimelstudio/interface/nodegraph_pnl.py
+++ b/src/gimelstudio/interface/nodegraph_pnl.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Gimel Studio Copyright 2019-2022 by the Gimel Studio project contributors
+# Gimel Studio Copyright 2019-2023 by the Gimel Studio project contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/gimelstudio/interface/nodeproperties_pnl.py
+++ b/src/gimelstudio/interface/nodeproperties_pnl.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Gimel Studio Copyright 2019-2022 by the Gimel Studio project contributors
+# Gimel Studio Copyright 2019-2023 by the Gimel Studio project contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/gimelstudio/interface/panel_base.py
+++ b/src/gimelstudio/interface/panel_base.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Gimel Studio Copyright 2019-2022 by the Gimel Studio project contributors
+# Gimel Studio Copyright 2019-2023 by the Gimel Studio project contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/gimelstudio/interface/preferences_dlg.py
+++ b/src/gimelstudio/interface/preferences_dlg.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Gimel Studio Copyright 2019-2022 by the Gimel Studio project contributors
+# Gimel Studio Copyright 2019-2023 by the Gimel Studio project contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/gimelstudio/interface/startup_splash.py
+++ b/src/gimelstudio/interface/startup_splash.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Gimel Studio Copyright 2019-2022 by the Gimel Studio project contributors
+# Gimel Studio Copyright 2019-2023 by the Gimel Studio project contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/gimelstudio/interface/statusbar.py
+++ b/src/gimelstudio/interface/statusbar.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Gimel Studio Copyright 2019-2022 by the Gimel Studio project contributors
+# Gimel Studio Copyright 2019-2023 by the Gimel Studio project contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/gimelstudio/interface/utils/ui.py
+++ b/src/gimelstudio/interface/utils/ui.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Gimel Studio Copyright 2019-2022 by the Gimel Studio project contributors
+# Gimel Studio Copyright 2019-2023 by the Gimel Studio project contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/gimelstudio/node_importer.py
+++ b/src/gimelstudio/node_importer.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Gimel Studio Copyright 2019-2022 by the Gimel Studio project contributors
+# Gimel Studio Copyright 2019-2023 by the Gimel Studio project contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/gimelstudio/utils/drawing.py
+++ b/src/gimelstudio/utils/drawing.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Gimel Studio Copyright 2019-2022 by the Gimel Studio project contributors
+# Gimel Studio Copyright 2019-2023 by the Gimel Studio project contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/gimelstudio/utils/exceptions.py
+++ b/src/gimelstudio/utils/exceptions.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Gimel Studio Copyright 2019-2022 by the Gimel Studio project contributors
+# Gimel Studio Copyright 2019-2023 by the Gimel Studio project contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/gimelstudio/utils/image.py
+++ b/src/gimelstudio/utils/image.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Gimel Studio Copyright 2019-2022 by the Gimel Studio project contributors
+# Gimel Studio Copyright 2019-2023 by the Gimel Studio project contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Gimel Studio Copyright 2019-2022 by the Gimel Studio project contributors
+# Gimel Studio Copyright 2019-2023 by the Gimel Studio project contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/nodes/corenodes/adjust/brightness_contrast_node/brightness_contrast_node.py
+++ b/src/nodes/corenodes/adjust/brightness_contrast_node/brightness_contrast_node.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Gimel Studio Copyright 2019-2022 by the Gimel Studio project contributors
+# Gimel Studio Copyright 2019-2023 by the Gimel Studio project contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/nodes/corenodes/blend/alpha_over_node/alpha_over_node.py
+++ b/src/nodes/corenodes/blend/alpha_over_node/alpha_over_node.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Gimel Studio Copyright 2019-2022 by the Gimel Studio project contributors
+# Gimel Studio Copyright 2019-2023 by the Gimel Studio project contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/nodes/corenodes/blend/mix_node/mix_node.py
+++ b/src/nodes/corenodes/blend/mix_node/mix_node.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Gimel Studio Copyright 2019-2022 by the Gimel Studio project contributors
+# Gimel Studio Copyright 2019-2023 by the Gimel Studio project contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/nodes/corenodes/color/color_balance_node/color_balance_node.py
+++ b/src/nodes/corenodes/color/color_balance_node/color_balance_node.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Gimel Studio Copyright 2019-2022 by the Gimel Studio project contributors
+# Gimel Studio Copyright 2019-2023 by the Gimel Studio project contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/nodes/corenodes/draw/add_text_node.py
+++ b/src/nodes/corenodes/draw/add_text_node.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Gimel Studio Copyright 2019-2022 by the Gimel Studio project contributors
+# Gimel Studio Copyright 2019-2023 by the Gimel Studio project contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/nodes/corenodes/filter/blur_node.py
+++ b/src/nodes/corenodes/filter/blur_node.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Gimel Studio Copyright 2019-2022 by the Gimel Studio project contributors
+# Gimel Studio Copyright 2019-2023 by the Gimel Studio project contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/nodes/corenodes/filter/dilate_erode_node.py
+++ b/src/nodes/corenodes/filter/dilate_erode_node.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Gimel Studio Copyright 2019-2022 by the Gimel Studio project contributors
+# Gimel Studio Copyright 2019-2023 by the Gimel Studio project contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/nodes/corenodes/filter/opacity_node/opacity_node.py
+++ b/src/nodes/corenodes/filter/opacity_node/opacity_node.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Gimel Studio Copyright 2019-2022 by the Gimel Studio project contributors
+# Gimel Studio Copyright 2019-2023 by the Gimel Studio project contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/nodes/corenodes/input/checkered_image_node.py
+++ b/src/nodes/corenodes/input/checkered_image_node.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Gimel Studio Copyright 2019-2022 by the Gimel Studio project contributors
+# Gimel Studio Copyright 2019-2023 by the Gimel Studio project contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/nodes/corenodes/input/color_image_node.py
+++ b/src/nodes/corenodes/input/color_image_node.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Gimel Studio Copyright 2019-2022 by the Gimel Studio project contributors
+# Gimel Studio Copyright 2019-2023 by the Gimel Studio project contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/nodes/corenodes/input/color_node.py
+++ b/src/nodes/corenodes/input/color_node.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Gimel Studio Copyright 2019-2022 by the Gimel Studio project contributors
+# Gimel Studio Copyright 2019-2023 by the Gimel Studio project contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/nodes/corenodes/input/float_node.py
+++ b/src/nodes/corenodes/input/float_node.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Gimel Studio Copyright 2019-2022 by the Gimel Studio project contributors
+# Gimel Studio Copyright 2019-2023 by the Gimel Studio project contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/nodes/corenodes/input/image_node.py
+++ b/src/nodes/corenodes/input/image_node.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Gimel Studio Copyright 2019-2022 by the Gimel Studio project contributors
+# Gimel Studio Copyright 2019-2023 by the Gimel Studio project contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/nodes/corenodes/input/integer_node.py
+++ b/src/nodes/corenodes/input/integer_node.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Gimel Studio Copyright 2019-2022 by the Gimel Studio project contributors
+# Gimel Studio Copyright 2019-2023 by the Gimel Studio project contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/nodes/corenodes/input/noise_image_node.py
+++ b/src/nodes/corenodes/input/noise_image_node.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Gimel Studio Copyright 2019-2022 by the Gimel Studio project contributors
+# Gimel Studio Copyright 2019-2023 by the Gimel Studio project contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/nodes/corenodes/input/string_node.py
+++ b/src/nodes/corenodes/input/string_node.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Gimel Studio Copyright 2019-2022 by the Gimel Studio project contributors
+# Gimel Studio Copyright 2019-2023 by the Gimel Studio project contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/nodes/corenodes/input/vector_node.py
+++ b/src/nodes/corenodes/input/vector_node.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Gimel Studio Copyright 2019-2022 by the Gimel Studio project contributors
+# Gimel Studio Copyright 2019-2023 by the Gimel Studio project contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/nodes/corenodes/transform/flip_node.py
+++ b/src/nodes/corenodes/transform/flip_node.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Gimel Studio Copyright 2019-2022 by the Gimel Studio project contributors
+# Gimel Studio Copyright 2019-2023 by the Gimel Studio project contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/nodes/corenodes/transform/rotate_node.py
+++ b/src/nodes/corenodes/transform/rotate_node.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Gimel Studio Copyright 2019-2022 by the Gimel Studio project contributors
+# Gimel Studio Copyright 2019-2023 by the Gimel Studio project contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/nodes/customnodes/example1_node.py
+++ b/src/nodes/customnodes/example1_node.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Gimel Studio Copyright 2019-2022 by the Gimel Studio project contributors
+# Gimel Studio Copyright 2019-2023 by the Gimel Studio project contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/nodes/customnodes/example2_node/example2_node.py
+++ b/src/nodes/customnodes/example2_node/example2_node.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Gimel Studio Copyright 2019-2022 by the Gimel Studio project contributors
+# Gimel Studio Copyright 2019-2023 by the Gimel Studio project contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Description

Updates the copyright year to 2023 in all files with license headers.

For reference, the command I used was `fd -e py -x sed -i "s/\b2022\b/2023/g"`.

### Related issues

N/A

### Systems Tested On

N/A

### Checklist
- [x] I signed the [CLA](https://cla-assistant.io/GimelStudio/GimelStudio)
- [x] There are no unnecessary or out-of-scope changes in this PR
- [x] Gimel Studio runs successfully on the above system(s) with the changes in this PR
- [x] The changes in this PR follow the [style guides](https://github.com/GimelStudio/GimelStudio/blob/master/CONTRIBUTING.md#styleguides)
