### PR TITLE
Rename  `Setlang` method to `SetLang`

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -73,7 +73,7 @@ class MainApp(wx.App):
 
         # Setup the Locale
         self.InitI18n()
-        self.Setlang(self.language)
+        self.SetLang(self.language)
 
         # Show the application window
         self.frame = ApplicationFrame(app_config=self.app_config)
@@ -93,7 +93,7 @@ class MainApp(wx.App):
         self.locale.AddCatalogLookupPathPrefix(path)
         self.locale.AddCatalog(self.GetAppName())
 
-    def Setlang(self, language):
+    def SetLang(self, language):
         supported_langs = {
             "LANGUAGE_ENGLISH": "en",
             "LANGUAGE_FRENCH": "fr",


### PR DESCRIPTION
### Description

Rename  to the `Setlang` method to `SetLang`.

### Related issues
N/A

### Systems Tested On
None :roll_eyes:

### Checklist
- [x] I signed the [CLA](https://cla-assistant.io/GimelStudio/GimelStudio)
- [x] There are no unnecessary or out-of-scope changes in this PR
- [x] Gimel Studio runs successfully on the above system(s) with the changes in this PR
- [x] The changes in this PR follow the [style guides](https://github.com/GimelStudio/GimelStudio/blob/master/CONTRIBUTING.md#styleguides)
