### PR TITLE
Changed default value of image input in glsl_renderer.Render to None

### DIFF
--- a/src/gimelstudio/core/glsl_renderer.py
+++ b/src/gimelstudio/core/glsl_renderer.py
@@ -81,7 +81,7 @@ class GLSLRenderer(object):
             glsl_shader = str(fp.read())
         return glsl_shader
 
-    def Render(self, frag_shader, props, image=None, image2=None):
+    def Render(self, frag_shader, props, image, image2=None):
         hash_value = hashlib.md5(copy.copy(frag_shader).encode())
         vao = self._vaos.get(hash_value)
         self.WriteViewports(image, image2)

--- a/src/gimelstudio/core/glsl_renderer.py
+++ b/src/gimelstudio/core/glsl_renderer.py
@@ -81,7 +81,7 @@ class GLSLRenderer(object):
             glsl_shader = str(fp.read())
         return glsl_shader
 
-    def Render(self, frag_shader, props, image, image2=None):
+    def Render(self, frag_shader, props, image=None, image2=None):
         hash_value = hashlib.md5(copy.copy(frag_shader).encode())
         vao = self._vaos.get(hash_value)
         self.WriteViewports(image, image2)

--- a/src/gimelstudio/core/node/node.py
+++ b/src/gimelstudio/core/node/node.py
@@ -238,7 +238,7 @@ class Node(NodeView):
             "image": render_image
         }
 
-    def RenderGLSL(self, path, props, image, image2=None):
+    def RenderGLSL(self, path, props, image=None, image2=None):
         if self.shader_cache_enabled == True:
             if self.shader_cache == None:
                 self.shader_cache = self.LoadGLSL(path)

--- a/src/gimelstudio/core/node/node.py
+++ b/src/gimelstudio/core/node/node.py
@@ -238,7 +238,9 @@ class Node(NodeView):
             "image": render_image
         }
 
-    def RenderGLSL(self, path, props, image=None, image2=None):
+    def RenderGLSL(self, path, props, image, image2=None):
+        if image is None:
+            image = Image(200, 200)
         if self.shader_cache_enabled == True:
             if self.shader_cache == None:
                 self.shader_cache = self.LoadGLSL(path)

--- a/src/gimelstudio/core/node/node.py
+++ b/src/gimelstudio/core/node/node.py
@@ -223,7 +223,7 @@ class Node(NodeView):
         if self.IsMuted():
             return self.MutedNodeEvaluation
         return self.NodeEvaluation
- 
+
     def EvalMutedNode(self, eval_info):
         try:
             image = self.EvalProperty(eval_info, "in_image").GetImage()
@@ -232,15 +232,13 @@ class Node(NodeView):
         render_image = Image()
         render_image.SetAsImage(image)
         self.NodeUpdateThumb(render_image)
-        
+
         # TODO: support multi-outputs
         return {
             "image": render_image
         }
 
-    def RenderGLSL(self, path, props, image, image2=None):
-        if image is None:
-            image = Image(200, 200)
+    def RenderGLSL(self, path, props, image=Image(200, 200), image2=None):
         if self.shader_cache_enabled == True:
             if self.shader_cache == None:
                 self.shader_cache = self.LoadGLSL(path)


### PR DESCRIPTION
<!-- Add a description -->
Input nodes currently use oiio instead of GLSL, meaning that they never go through glsl_renderer.Renderer() function. 
The nodes that use this function all have an input, meaning that the function's image input did not require a default value. 
To use this function (and GLSL shaders) with input functions, the input as given a default value of None.

<!-- List any related issues (if applicable) -->
No related issues

<!-- List the systems you have tested this PR on (e.g: Windows 10, Ubuntu 20 LTS, etc) -->
Windows 10

<!-- A couple of things to check -->
### Checklist
- [x] I signed the [CLA](https://cla-assistant.io/GimelStudio/GimelStudio)
- [x] There are no unnecessary or out-of-scope changes in this PR
- [x] Gimel Studio runs successfully on the above system(s) with the changes in this PR
- [x] The changes in this PR follow the [style guides](https://github.com/GimelStudio/GimelStudio/blob/master/CONTRIBUTING.md#styleguides)
