### PR TITLE
Fix #198: Close add node menu on defocus

### DIFF
--- a/src/gimelstudio/interface/addnode_menu.py
+++ b/src/gimelstudio/interface/addnode_menu.py
@@ -153,10 +153,13 @@ class AddNodeMenu(wx.PopupTransientWindow):
 
         self.SetBackgroundColour(const.ADD_NODE_MENU_BG)
 
-        self.Bind(wx.EVT_KILL_FOCUS, self.Dismiss)
+        self.Bind(wx.EVT_KILL_FOCUS, self.OnDismiss)
 
         self.InitRegistryMapping()
         self.InitAddNodeMenuUI()
+
+    def OnDismiss(self, event):
+        self.Dismiss()
 
     def InitRegistryMapping(self):
         i = 0

--- a/src/gimelstudio/interface/addnode_menu.py
+++ b/src/gimelstudio/interface/addnode_menu.py
@@ -153,6 +153,8 @@ class AddNodeMenu(wx.PopupTransientWindow):
 
         self.SetBackgroundColour(const.ADD_NODE_MENU_BG)
 
+        self.Bind(wx.EVT_KILL_FOCUS, self.Dismiss)
+
         self.InitRegistryMapping()
         self.InitAddNodeMenuUI()
 


### PR DESCRIPTION
### Description
`wx.PopupTransientWindow` is only used once in Gimel Studio's source code which is in the add node menu, but for whatever reason does not always close on defocus.

@POMXARK Can you please check if this PR fixes this issue?

(side note for @Correct-Syntax: I do recall there being an issue on Ubuntu a while back when I tried, however I don't have access to that computer right now + both wxPython 4.1.1 and 4.2.1 are failing to install on my current Linux machine so can't check myself sorry)

### Related issues
Resolves: #198

### Systems Tested On

### Checklist
- [x] I signed the [CLA](https://cla-assistant.io/GimelStudio/GimelStudio)
- [x] There are no unnecessary or out-of-scope changes in this PR
- [x] Gimel Studio runs successfully on the above system(s) with the changes in this PR
- [x] The changes in this PR follow the [style guides](https://github.com/GimelStudio/GimelStudio/blob/master/CONTRIBUTING.md#styleguides)
